### PR TITLE
BUGFIX Handle empty CC correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 node_modules/
 yarn-error.log
 
+# IntelliJ
+.idea/*
+*/.idea/*
+!.idea/runConfigurations
+!.idea/codeStyles
+!.idea/codeStyleSettings.xml
+

--- a/server/src/store-mail-in-db.mjs
+++ b/server/src/store-mail-in-db.mjs
@@ -48,8 +48,8 @@ export default async function storeMailInDb({
         }),
     ]);
 
-    let toArray = Array.isArray(to) ? to : [to];
-    let ccArray = Array.isArray(cc) ? cc : [cc];
+    const toArray = [to].flat();
+    const ccArray = [cc].flat().filter(x => !!x);
 
     const message = {
         from: from && { value: from.value, text: from.text },


### PR DESCRIPTION
Fixes an error, where `[null]` is returned as list of CCs, resulting in the following frontend error:

```
meta.js:42 Uncaught (in promise) TypeError: Cannot read property 'text' of null
    at meta.js:42
    at Array.map (<anonymous>)
    at u.e [as constructor] (meta.js:41)
    at u.T [as render] (index.js:513)
    at m (index.js:181)
    at g (children.js:137)
    at x (index.js:404)
    at m (index.js:232)
    at g (children.js:137)
    at m (index.js:198)
```